### PR TITLE
- feature: added list-remote command

### DIFF
--- a/src/command_handlers/list_remote.rs
+++ b/src/command_handlers/list_remote.rs
@@ -1,0 +1,59 @@
+use clap::{error::ErrorKind, ArgMatches, Command, Error};
+use reqwest::get;
+use serde::Deserialize;
+
+use crate::{
+    config::config_manager::ConfigManager, utils::utils::get_shinkai_node_binaries_versions_url,
+};
+
+#[derive(Deserialize)]
+struct Versions {
+    pub latest: String,
+    pub versions: Vec<String>,
+}
+
+pub async fn list_remote(
+    command: &Command,
+    _sub_matches: &ArgMatches,
+    mut _config_manager: ConfigManager,
+) {
+    println!("⌛ Fetching versions from remote...\n");
+    let versions_definition_response = get(get_shinkai_node_binaries_versions_url()).await;
+    let mut versions_definition = match versions_definition_response {
+        Ok(response) => {
+            if response.status().is_success() {
+                match response.json::<Versions>().await {
+                    Ok(versions) => versions,
+                    Err(e) => {
+                        let error =
+                            Error::raw(ErrorKind::Io, format!("❌ Error parsing versions: {}", e))
+                                .with_cmd(command);
+                        error.exit();
+                    }
+                }
+            } else {
+                let error = Error::raw(
+                    ErrorKind::Io,
+                    format!("❌ Failed to fetch versions. Status: {}", response.status()),
+                )
+                .with_cmd(command);
+                error.exit();
+            }
+        }
+        Err(e) => {
+            let error = Error::raw(ErrorKind::Io, format!("❌ Error fetching versions: {}", e))
+                .with_cmd(command);
+            error.exit();
+        }
+    };
+
+    for version in versions_definition.versions.iter() {
+        if version == &versions_definition.latest {
+            println!("🏷️ {} (✨latest)", version);
+        } else {
+            println!("🏷️ {}", version);
+        }
+    }
+    println!("\n💡 Install any of these versions running:");
+    println!("\t 'kaivm install [version]'");
+}

--- a/src/command_handlers/mod.rs
+++ b/src/command_handlers/mod.rs
@@ -1,4 +1,5 @@
 pub mod list;
+pub mod list_remote;
 pub mod install;
 pub mod r#use;
 pub mod run;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ fn cli() -> Command {
         .about("A Shinkai Node versioning CLI")
         .subcommand_required(true)
         .subcommand(Command::new("list").short_flag('l').long_flag("list").long_flag_alias("ls").about("List all Shinkai Node installed versions"))
+        .subcommand(Command::new("list-remote").short_flag('r').long_flag("list-remote").long_flag_alias("lr").about("List all Shinkai Node versions"))
         .subcommand(
             Command::new("install")
                 .short_flag('i')
@@ -68,6 +69,9 @@ async fn main() {
     match matches.subcommand() {
         Some(("list", sub_matches)) => {
             command_handlers::list::list(&cli(), sub_matches, config_manager)
+        }
+        Some(("list-remote", sub_matches)) => {
+            command_handlers::list_remote::list_remote(&cli(), sub_matches, config_manager).await
         }
         Some(("install", sub_matches)) => {
             command_handlers::install::install(&cli(), sub_matches, config_manager).await

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -52,7 +52,15 @@ pub fn get_shinkai_node_binary_url(version: &String) -> String {
         "https://download.shinkai.com/shinkai-node/binaries/{}/shinkai-node-{}{}",
         get_arch(),
         version,
-        if cfg!(target_os = "windows") { ".exe" } else { "" },
+        if cfg!(target_os = "windows") {
+            ".exe"
+        } else {
+            ""
+        },
     );
     url
+}
+
+pub fn get_shinkai_node_binaries_versions_url() -> String {
+    "https://download.shinkai.com/shinkai-node/binaries/versions.json".to_string()
 }


### PR DESCRIPTION
Using `kaivm list-remote` you can fetch all available versions from Shinkai Node repository